### PR TITLE
refac: Use RestController and RestControllerAdvice for pure REST APIs

### DIFF
--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/controller/CustomerController.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/controller/CustomerController.kt
@@ -5,10 +5,10 @@ import com.github.thorlauridsen.dto.CustomerInputDto
 import com.github.thorlauridsen.dto.toDto
 import com.github.thorlauridsen.service.CustomerService
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
-import org.springframework.stereotype.Controller
 import java.net.URI
 import java.util.UUID
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * This REST controller consists of endpoints for:
@@ -21,7 +21,7 @@ import java.util.UUID
  *
  * @param customerService [CustomerService] service layer.
  */
-@Controller
+@RestController
 class CustomerController(private val customerService: CustomerService) : ICustomerController {
 
     /**

--- a/apps/api/src/main/kotlin/com/github/thorlauridsen/exception/ControllerAdvisor.kt
+++ b/apps/api/src/main/kotlin/com/github/thorlauridsen/exception/ControllerAdvisor.kt
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
-import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
@@ -16,7 +16,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  * Controller advisor for handling exceptions.
  * This ensures that whenever an exception is thrown, a proper error response is returned to the client.
  */
-@ControllerAdvice
+@RestControllerAdvice
 class ControllerAdvisor : ResponseEntityExceptionHandler() {
 
     private val logger = LoggerFactory.getLogger(this::class.java)


### PR DESCRIPTION
We should always use the annotations `RestController` and `RestControllerAdvice` for pure REST APIs. This commit updates the Spring Boot annotations.